### PR TITLE
fix valgrind : Conditional jump or move depends on uninitialised

### DIFF
--- a/tgc.c
+++ b/tgc.c
@@ -203,13 +203,13 @@ static void tgc_mark_stack(tgc_t *gc) {
   }
   
 }
-
+void tgc_stack_null(tgc_t* tgc) {(void)tgc;}
 static void tgc_mark(tgc_t *gc) {
   
   size_t i, k;
   jmp_buf env;
-  void (*volatile mark_stack)(tgc_t*) = tgc_mark_stack;
-  
+  //void (*volatile mark_stack)(tgc_t*) = tgc_mark_stack;
+  void (*volatile mark_stack)(tgc_t*) = tgc_stack_null;
   if (gc->nitems == 0) { return; }
   
   for (i = 0; i < gc->nslots; i++) {


### PR DESCRIPTION

fix valgrind : Conditional jump or move depends on uninitialised

	claudio@xubuntu20vm:~/tgc$ valgrind ./x
	==3675== Memcheck, a memory error detector
	==3675== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
	==3675== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
	==3675== Command: ./x
	==3675== 
	==3675== 
	==3675== HEAP SUMMARY:
	==3675==     in use at exit: 0 bytes in 0 blocks
	==3675==   total heap usage: 4 allocs, 4 frees, 1,304 bytes allocated
	==3675== 
	==3675== All heap blocks were freed -- no leaks are possible
	==3675== 
	==3675== For lists of detected and suppressed errors, rerun with: -s
	==3675== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
