### PR TITLE
docs: fix simple typo, tranform -> transform

### DIFF
--- a/examples/oggenc.c
+++ b/examples/oggenc.c
@@ -44461,7 +44461,7 @@ static int _vds_shared_init(vorbis_dsp_state *v,vorbis_info *vi,int encp){
   b->transform[0]=_ogg_calloc(VI_TRANSFORMB,sizeof(*b->transform[0]));
   b->transform[1]=_ogg_calloc(VI_TRANSFORMB,sizeof(*b->transform[1]));
 
-  /* MDCT is tranform 0 */
+  /* MDCT is transform 0 */
 
   b->transform[0][0]=_ogg_calloc(1,sizeof(mdct_lookup));
   b->transform[1][0]=_ogg_calloc(1,sizeof(mdct_lookup));


### PR DESCRIPTION
There is a small typo in examples/oggenc.c.

Should read `transform` rather than `tranform`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md